### PR TITLE
Update JsxStyleProps name import

### DIFF
--- a/website/pages/docs/concepts/style-props.mdx
+++ b/website/pages/docs/concepts/style-props.mdx
@@ -165,14 +165,14 @@ You can use these types to get type safety in your components.
 
 ### Style Object
 
-Use the `JSXStyleProps` to get the types of the style object that is compatible with JSX elements.
+Use the `JsxStyleProps` to get the types of the style object that is compatible with JSX elements.
 
 ```jsx {2}
 import { styled } from '../styled-system/jsx'
-import type { JSXStyleProps } from '../styled-system/types'
+import type { JsxStyleProps } from '../styled-system/types'
 
 type ButtonProps = {
-  color?: JSXStyleProps['color']
+  color?: JsxStyleProps['color']
 }
 
 const Button = (props: ButtonProps) => {


### PR DESCRIPTION
JSXStyleProps is not exported!

The correct name is JsxStyleProps. 

This PR fix de documentation change JSXStyleProps to JsxStyleProps

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Panda users. -->

## 📝 Additional Information
